### PR TITLE
Adds custom rule and checks for section + heading

### DIFF
--- a/lib/custom_a11y_rules.js
+++ b/lib/custom_a11y_rules.js
@@ -74,7 +74,22 @@ var customRules = {
                 'help': 'All <i> elements should have aria-hidden="true"',
                 'helpUrl': 'https://openedx.atlassian.net/wiki/display/A11Y/edX+Specific+Accessibility+Tests'
             }
-        }
+        },
+        {
+            'id': 'section',
+            'selector': 'section',
+            'enabled': true,
+            'excludeHidden': false,
+            'tags': ['edx-custom'],
+            'all': ['section-heading-first-child'],
+            'any': [],
+            'none': [],
+            'metadata': {
+                'description': 'Ensures all sections have a heading as the first child',
+                'help': 'All <section> elements should have a heading as its first child',
+                'helpUrl': 'https://openedx.atlassian.net/wiki/display/A11Y/edX+Specific+Accessibility+Tests'
+            }
+        },
     ],
     'checks': [
         {
@@ -156,6 +171,26 @@ var customRules = {
             evaluate: function(node, options) {
                 return axe.utils.isHidden(node);
             },
-        }
+        },
+        {
+            'id': 'section-heading-first-child',
+            'metadata': {
+                'impact': 'minor',
+                'messages': {
+                    'pass': '<section> elements should have a heading as its first child',
+                    'fail': '<section> elements should have a heading as its first child'
+                }
+            },
+            evaluate: function(node, options) {
+                var childNode = node.children[0].nodeName,
+                    validHeadings = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
+                
+                if (validHeadings.indexOf(childNode) > -1) {
+                    return true;
+                } else {
+                    return false;
+                }
+            },
+        },
     ]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-custom-a11y-rules",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Custom rules for accessibility testing with aXe Core",
   "main": "",
   "scripts": {

--- a/test/fixtures/section-heading-first-fail.html
+++ b/test/fixtures/section-heading-first-fail.html
@@ -1,0 +1,3 @@
+<section>
+    <p>Hello, world.</p>
+</section>

--- a/test/fixtures/section-heading-first-pass.html
+++ b/test/fixtures/section-heading-first-pass.html
@@ -1,0 +1,23 @@
+<section>
+    <h1>Hello, world.</h1>
+</section>
+
+<section>
+    <h2>Hello, world.</h2>
+</section>
+
+<section>
+    <h3>Hello, world.</h3>
+</section>
+
+<section>
+    <h4>Hello, world.</h4>
+</section>
+
+<section>
+    <h5>Hello, world.</h5>
+</section>
+
+<section>
+    <h6>Hello, world.</h6>
+</section>

--- a/test/spec/checks_spec.js
+++ b/test/spec/checks_spec.js
@@ -83,7 +83,7 @@ describe('Checks Spec', function(){
             selector: 'a#empty-href',
             fixture: 'link-href-value-fail.html',
             result: false
-        },  {
+        }, {
             checkId: 'link-href-internal',
             selector: 'a',
             fixture: 'link-href-pass.html',
@@ -143,7 +143,17 @@ describe('Checks Spec', function(){
             selector: 'span.icon',
             fixture: 'icon-aria-hidden-fail.html',
             result: false
-        }
+        }, {
+            checkId: 'section-heading-first-child',
+            selector: 'section',
+            fixture: 'section-heading-first-fail.html',
+            result: false
+        }, {
+            checkId: 'section-heading-first-child',
+            selector: 'section',
+            fixture: 'section-heading-first-pass.html',
+            result: true
+        },
     ];
 
 

--- a/test/spec/rules_spec.js
+++ b/test/spec/rules_spec.js
@@ -108,7 +108,15 @@ describe('Rules Spec', function () {
                 rule: 'caption',
                 fixture: 'media.html',
                 expectedResult: notRun(),
-            }
+            }, {
+                rule: 'section',
+                fixture: 'section-heading-first-fail.html',
+                expectedResult: fail()
+            }, {
+                rule: 'section',
+                fixture: 'section-heading-first-pass.html',
+                expectedResult: pass(6)
+            },
         ];
 
     specCases.forEach(function(context){ runRuleSpec(context); });


### PR DESCRIPTION
# [AC-414](https://github.com/edx/edx-platform/pull/12452)

This is part of AC-414 and adds two additional custom a11y rules/checks ensuring a heading is always the first child of any section element.

I've marked this test as "minor" since WCAG suggests it's a "should do", rather than a "must do".

The version has been bumped to indicate this update, but the edx/edx-platform repository pulls from master, rather than NPMJS.org and a specific version.

## Reviewers

- [x] @benpatterson 
- [x] @cptvitamin FYI