### PR TITLE
add invalid id rule and check (TE-1919)

### DIFF
--- a/lib/custom_a11y_rules.js
+++ b/lib/custom_a11y_rules.js
@@ -11,6 +11,23 @@ var customRules = {
             'tags': [ 'edx-custom' ]
         },
         {
+            'id': 'valid-ids',
+            'selector': '[id^="0"],[id^="1"],[id^="2"],[id^="3"],[id^="4"],[id^="5"],[id^="6"],[id^="7"],' +
+                        '[id^="8"],[id^="9"]',
+            'enabled': true,
+            'tags': [ 'edx-custom' ],
+            'all': [],
+            'any': [],
+            'none': [
+                'invalid-id-extant'
+            ],
+            'metadata': {
+                'description': 'Ensures element ids do not start with a number.',
+                'help': 'Element ids MUST not start with a number.',
+                'helpUrl': 'https://openedx.atlassian.net/wiki/display/A11Y/edX+Specific+Accessibility+Tests'
+            }
+        },
+        {
             'id': 'nav-aria-label',
             'selector': 'nav',
             'enabled': true,
@@ -203,7 +220,7 @@ var customRules = {
 
                 var childNode = node.children[0].nodeName,
                     validHeadings = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
-                
+
                 if (childNode === 'HEADER' && node.children[0].children.length > 0) {
                     childNode = node.children[0].children[0].nodeName;
                 }
@@ -223,12 +240,27 @@ var customRules = {
             evaluate: function(node, options) {
                 var elem = node.nodeName,
                     validElems = ['SPAN'];
-                    
+
                 if (validElems.indexOf(elem) > -1) {
                     return true;
                 } else {
                     return false;
                 }
+            }
+        },
+        {
+            'id': 'invalid-id-extant',
+            'metadata': {
+                'impact': 'critical',
+                'messages': {
+                    'pass': 'element ids must not start with a number',
+                    'fail': 'element ids must not start with a number'
+                },
+            },
+            evaluate: function(node, options) {
+                var nodeName = node.nodeName,
+                    validElems = ['IFRAME'];
+                return (validElems.indexOf(nodeName) === -1);
             }
         }
     ]

--- a/test/fixtures/valid-ids-fail.html
+++ b/test/fixtures/valid-ids-fail.html
@@ -1,0 +1,10 @@
+<div id="0abc">0abc</div>
+<div id="1">1</div>
+<div id="222">222</div>
+<div id="3-abc">3-abc</div>
+<div id="4_abc">4_abc</div>
+<div id="5*">5*</div>
+<div id="6">6</div>
+<div id="7">7</div>
+<div id="8">8</div>
+<div id="9">9</div>

--- a/test/fixtures/valid-ids-pass.html
+++ b/test/fixtures/valid-ids-pass.html
@@ -1,0 +1,7 @@
+<div id="aaaaaa">aaaaaa</div>
+<div id="a1">a1</div>
+<div id="http://google.com">http://google.com</div>
+<div id="a-2">a-2</div>
+<div id="*">*</div>
+<div id="a_3">a_3</div>
+<iframe id="12345">12345</iframe>

--- a/test/spec/rules_spec.js
+++ b/test/spec/rules_spec.js
@@ -124,6 +124,14 @@ describe('Rules Spec', function () {
                 rule: 'icon-element',
                 fixture: 'icon-correct-element-fail.html',
                 expectedResult: fail(2)
+            }, {
+                rule: 'valid-ids',
+                fixture: 'valid-ids-pass.html',
+                expectedResult: pass(1)
+            }, {
+                rule: 'valid-ids',
+                fixture: 'valid-ids-fail.html',
+                expectedResult: fail(10)
             },
         ];
 


### PR DESCRIPTION
This PR provides a new rule and check: element ids must not start with a number. I marked this violation as `critical` because although a numeric id isn't problematic in its own right (it's actually [valid in HTML5](https://www.w3.org/TR/html5/dom.html#the-id-attribute)), it can and will break CI tools (including `axe-core` itself), which harms their reliability and introduces the potential for accessibility violations to go undetected. However, I'm willing to change this if necessary.

Within this rule, the selector does the heavy lifting. Because we aren't referencing the numeric ids directly (e.g. `#12345`), axe doesn't choke, plus it only runs against the problematic elements which is more performant. I added a special case for iframes, though, since sometimes their ids are set by external sources over which we may have no control.

Upon approval:
- [ ] Update [docs](https://openedx.atlassian.net/wiki/display/A11Y/edX+Specific+Accessibility+Tests)
- [ ] Squash