### PR TITLE
TE-2646 Skip leanModal link target verification

### DIFF
--- a/lib/custom_a11y_rules.js
+++ b/lib/custom_a11y_rules.js
@@ -182,8 +182,10 @@ var customRules = {
                 }
             },
             evaluate: function(node, options) {
-                var href = node.getAttribute('href') || '', linkTarget;
-                if (href.startsWith('#') && href.length > 1) {
+                var href = node.getAttribute('href') || '',
+                    linkTarget,
+                    rel = node.getAttribute('rel') || '';
+                if (href.startsWith('#') && href.length > 1 && rel !== 'leanModal') {
                     linkTarget = document.querySelector(href);
                     return axe.commons.dom.isFocusable(linkTarget);
                 } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-custom-a11y-rules",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Custom rules for accessibility testing with aXe Core",
   "main": "",
   "scripts": {

--- a/test/fixtures/link-href-value-modal.html
+++ b/test/fixtures/link-href-value-modal.html
@@ -1,0 +1,2 @@
+<a id="unfocusable-target" href="#unfocusable-div" rel="leanModal"></a>
+<div id="unfocusable-div">Div</div>

--- a/test/spec/rules_spec.js
+++ b/test/spec/rules_spec.js
@@ -78,6 +78,10 @@ describe('Rules Spec', function () {
                 expectedResult: fail(4)
             }, {
                 rule: 'link-href',
+                fixture: 'link-href-value-modal.html',
+                expectedResult: pass()
+            }, {
+                rule: 'link-href',
                 fixture: 'link-href-pass.html',
                 expectedResult: pass()
             }, {


### PR DESCRIPTION
Skip validation of the target for links which trigger a `jquery.leanModal` dialog.  This is a known minor a11y issue in edx-platform, but is less important to resolve than other a11y issues and is blocking a switch from PhantomJS to headless Chrome for our automated a11y tests.  (PhantomJS only occasionally finds and reports this problem, but Chrome does so consistently.)  We can revert this change once the modal dialog triggers in edx-platform have been updated (for example, to use buttons instead).