### PR TITLE
Publish new tags to npmjs.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,10 @@ before_script:
 script:
     - make test
     - make quality
+deploy:
+    provider: npm
+    api_key:
+      secure: t7yvnnaCriHopZD8JQoxW1M2Vcvl5HPTrDCtbqYYplA1JrvWhbvtMTJ5BOFQXMIC4T3PPKPEWv56U/rbneFh9L/AHmqBtEqBImTqWC7kWYVk4Aye7vJ/hqPj6HahUGprhPpjoiNrJYWGE6MYA9k6bh0eBfUWkju6AW2p13f6QUiNBg6PUUCrUFxL7BBYhLqFlr0QvJi2/48wTLImDNahAq5heLr0mGbtAfHcFflNcbWb74C6HiydrQO+gSKYQm+CvK0LDzJodILcwTkEp3J+KCeIZxVYy8e0Ma3lq2c9aCvZfvj489Vv9DJ17zQSNh9mcsi6xDrMD2njpb6V0eZvB56IdZ9yQZvPiyj0A4SpwTLa1kO7FD+RT8qdmOBk1EgSRT9wtGGU74kPQx3jd7vpkN6X+dtgj2TFj/Ty1JVdkXlYyEPY6jVgbJ52UwRIrHzyCImBfG5/Gsrmgyix4LIBQz2QjuSpGq9Y9bbO1+l9JEplx9548mmTjnJFh/FOiTj5WhXLlLC2y7Ji5l94w/gct6KFhFO52zVxMbKuhXMPlt6ecj6NVJJNArdnXGS3hBo6Pr0sKjgo46okg47Fr61orjz658bxeJVfEBPGLIHgQoahOEUloZZ1ffKSfg0ZB3X5zKnY167AcouqoWiXVThU+dJJrC6lNOd6XmzznNSCyAA=
+    on:
+      tags: true
+      branch: master


### PR DESCRIPTION
Based on https://docs.travis-ci.com/user/deployment/npm/

Both Paragon and studio-frontend do this differently, and the package paragon uses [tells us to use Stages](https://www.npmjs.com/package/travis-deploy-once) (which studio-frontend uses) or just to use what travis provides.  

I went for "simple" but am happy to deploy whatever way we want to, I'm just here to provide the NPM key and to update a wiki page about it.

Done for https://openedx.atlassian.net/browse/DEVOPS-7756