### PR TITLE
Bump axe-core version to 3.2.2

### DIFF
--- a/lib/custom_a11y_rules.js
+++ b/lib/custom_a11y_rules.js
@@ -55,9 +55,9 @@ var customRules = {
             'any': ['skip-link'],
             'none': [],
             'metadata': {
-                'description': 'Ensures the first link on the page is a skip link',
-                'help': 'The page should have a skip link as its first link',
-                'helpUrl': 'https://dequeuniversity.com/rules/axe/1.1/skip-link'
+                'description': 'Ensures that all skip links have a valid target',
+                'help': 'All skip links should have a valid target, allowing users to skip the navigation',
+                'helpUrl': 'https://dequeuniversity.com/rules/axe/3.2/skip-link'
             }
         },
         {
@@ -117,6 +117,7 @@ var customRules = {
                 }
             },
             evaluate: function(node, options) {
+                axe._tree = axe.utils.getFlattenedTree(node);
                 return axe.commons.aria.label(node) !== null;
             }
         },
@@ -132,6 +133,7 @@ var customRules = {
                 }
             },
             evaluate: function(node, options) {
+                axe._tree = axe.utils.getFlattenedTree(node);
                 var label = axe.commons.aria.label(node) || '',
                     words = label.toLowerCase().split(' ');
                 return words.indexOf('nav') < 0 && words.indexOf('navigation') < 0;
@@ -170,6 +172,9 @@ var customRules = {
                     rel = node.getAttribute('rel') || '';
                 if (href.startsWith('#') && href.length > 1 && rel !== 'leanModal') {
                     linkTarget = document.querySelector(href);
+                    if (!linkTarget) {
+                        return false;
+                    }
                     return axe.commons.dom.isFocusable(linkTarget);
                 } else {
                     return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-custom-a11y-rules",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Custom rules for accessibility testing with aXe Core",
   "main": "",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/edx/edx-custom-a11y-rules#readme",
   "devDependencies": {
-    "axe-core": "~1.1.0",
+    "axe-core": "~3.2.2",
     "jasmine-core": "^2.3.4",
     "jshint": "^2.8.0",
     "karma": "^0.13.10",

--- a/test/fixtures/skip-link-fail.html
+++ b/test/fixtures/skip-link-fail.html
@@ -1,3 +1,2 @@
-{# This will fail despite the href being OK because "main-content" div isn't focusable. #}
-<a href="#main-content">Skip to main content</a>
+<a href="#not-a-real-element">Skip to main content</a>
 <div id="main-content">Main content</div>

--- a/test/spec/rules_spec.js
+++ b/test/spec/rules_spec.js
@@ -32,7 +32,7 @@ describe('Rules Spec', function () {
                 axe.configure(rules);
                 jasmine.getFixtures().fixturesPath = '/base/';
                 loadFixtures('test/fixtures/' + fixture);
-                axe.a11yCheck(document, {}, function (r) { results = r; done(); });
+                axe.run(document, function (err, result) { results = result; done(); });
             });
 
             it(fixture + ', should ' + expectedResult, function () {


### PR DESCRIPTION
* Jump from axe-core `1.1.0` to `3.2.2`
* `axe.a11yAudit` has been removed in favor of `axe.run`
* For the `nav-aria-label-value` and `nav-aria-label-present`, I was seeing failures saying: `TypeError: axe._tree is undefined in /home/travis/build/edx/edx-custom-a11y-rules/node_modules/axe-core/axe.min.js`. I followed what the axe-core repo does for this, and defined the `axe._tree` inside the test: [Link to example in the axe-core repo](https://github.com/dequelabs/axe-core/blob/a4255da17c736bfa740790e61f8f69635866d4da/test/commons/text/accessible-text.js#L15)
* The old `axe.commons.dom.isFocusable` did an early check to see if an element was null: [1.1.0 code link](https://github.com/dequelabs/axe-core/blob/8558b231e0eee395c4f1e2e3f1acc1e1b7e52e93/lib/commons/dom/is-focusable.js#L12), but not anymore: [3.2.2 code link](https://github.com/dequelabs/axe-core/blob/9556393cab10e2836b1cd6cd0c59bb4c1f231222/lib/commons/dom/is-focusable.js#L25). So I added a null check to fix some failures I was seeing.
* The skip-link rule no longer requires a focusable element, so our current `skip-link-fail.html` was actually passing: [Link to PR that changed this check](https://github.com/dequelabs/axe-core/pull/612). So I changed the html file to represent a valid failure.