### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/edx/edx-custom-a11y-rules.svg?branch=master
-    :target: https://travis-ci.org/edx/edx-custom-a11y-rules
+.. image:: https://travis-ci.com/edx/edx-custom-a11y-rules.svg?branch=master
+    :target: https://travis-ci.com/edx/edx-custom-a11y-rules
 
 
 Overview


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089