### PR TITLE
Switch from Travis CI to GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Node CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        node-version: ['0.10', '0.12']
+
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v2
+
+    - name: setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Setup Environment
+      run: |
+        npm install
+        export DISPLAY=:99.0
+        sudo apt-get install xvfb
+
+    - name: Run Tests
+      run: xvfb-run ./node_modules/.bin/karma start --single-run
+
+    - name: Run Quality
+      run: xvfb-run ./node_modules/.bin/jshint lib/ test/

--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -1,0 +1,30 @@
+name: Node.js Package Publishing
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '0.12'
+
+    - name: Install Dependencies
+      run: npm install
+
+    - name: Build package
+      run: npm run build
+
+    - name: Publish Package
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
+      run: npm run semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ branches:
         - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 before_script:
     - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
+
+services:
+    - xvfb
+
 script:
     - make test
     - make quality

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-.. image:: https://travis-ci.org/edx/edx-custom-a11y-rules.svg?branch=master
-    :target: https://travis-ci.org/edx/edx-custom-a11y-rules
-
+.. image:: https://github.com/edx/edx-custom-a11y-rules/workflows/NodeCI/badge.svg?branch=master
+    :target: https://github.com/edx/edx-custom-a11y-rules/actions?query=workflow%3A%22Node+CI%22
+    :alt: GitHub CI
 
 Overview
 --------


### PR DESCRIPTION
**Issue:** [BOM-2110](https://openedx.atlassian.net/browse/BOM-2110)

### Description
- Added `GitHub CI` to run tests along with `Travis`.
- Updated `README.rst` to show `GitHub CI` badge status.

### Follow Up Work
- `Travis` will be removed in the follow-up PR. 
- Tests are also failing on Travis CI because of the old version of the code. Code will be updated to fix test failures in the issue [BOM-2610](https://openedx.atlassian.net/browse/BOM-2610)