### PR TITLE
Change node release to trigger on push

### DIFF
--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -1,8 +1,8 @@
 name: Node.js Package Publishing
-
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
This PR fixes the trigger event for node releases which was previously set to new github tags